### PR TITLE
Update names

### DIFF
--- a/lib/json1.ts
+++ b/lib/json1.ts
@@ -36,8 +36,8 @@ function assert(pred: any, msg?: string): asserts pred {
 let debugMode = false
 
 export const type = {
-  name: 'json1',
-  uri: "http://sharejs.org/types/JSONv1",
+  name: 'p',
+  uri: 'p',
   readCursor,
   writeCursor,
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typescript": "^3.9.5"
   },
   "scripts": {
-    "test": "mocha test/cursor.js test/test.js test/immutable.js",
+    "test": "mocha test/cursor.js test/test.js test/immutable.js test/presence.js",
     "fuzzer": "node test/fuzzer.js",
     "prepare": "rm -rf dist && npx tsc && terser -d process.env.JSON1_RELEASE_MODE=true -c pure_funcs=log,keep_fargs=false,passes=2 -b --source-map url -o dist/json1.release.js -- dist/json1.js"
   },


### PR DESCRIPTION
Update the name and URI to be just "p".

It seems that there is actually no reason for these to be long, they just need to be different from other types.

Since these are stored in MongoDB, I figure why not make it as small as possible.